### PR TITLE
Changed About page to about in _config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,7 +12,7 @@ highlighter: pygments
 # Links
 links:
   - title: "About"
-    url: /About
+    url: /about
   - title: "Twitter"
     url: http://twitter.com/alixedi
   - title: "Github"


### PR DESCRIPTION
Previous link was pointing to /About, now it's pointing to /about.
